### PR TITLE
fix(certificates): added centering for webkit

### DIFF
--- a/styles/certificates-styles.css
+++ b/styles/certificates-styles.css
@@ -189,6 +189,7 @@ header{
     object-fit: contain;
 }
 .card-title p{
+    text-align: center;
     margin: 0;
 }
 


### PR DESCRIPTION
Added dedicated centering for paragraphs of the cards. Now webkit browsers show the names of the certificates correctly.

Fixes #1